### PR TITLE
Reimplement Expr follow the book

### DIFF
--- a/compiler/src/main/scala/grox/Expr.scala
+++ b/compiler/src/main/scala/grox/Expr.scala
@@ -9,6 +9,8 @@ enum Expr:
   case Subtract(left: Expr, right: Expr)
   case Multiply(left: Expr, right: Expr)
   case Divide(left: Expr, right: Expr)
+  case And(left: Expr, right: Expr)
+  case Or(left: Expr, right: Expr)
 
   // Unary
   case Negate(expr: Expr)

--- a/compiler/src/main/scala/grox/Expr.scala
+++ b/compiler/src/main/scala/grox/Expr.scala
@@ -9,8 +9,6 @@ enum Expr:
   case Subtract(left: Expr, right: Expr)
   case Multiply(left: Expr, right: Expr)
   case Divide(left: Expr, right: Expr)
-  case And(left: Expr, right: Expr)
-  case Or(left: Expr, right: Expr)
 
   // Unary
   case Negate(expr: Expr)

--- a/compiler/src/main/scala/grox/Expr.scala
+++ b/compiler/src/main/scala/grox/Expr.scala
@@ -5,10 +5,20 @@ type LiteralType = Double | String | Boolean | Null
 enum Expr:
 
   // Binary
+
+  // arithmetic
   case Add(left: Expr, right: Expr)
   case Subtract(left: Expr, right: Expr)
   case Multiply(left: Expr, right: Expr)
   case Divide(left: Expr, right: Expr)
+
+  // comparison
+  case Greater(left: Expr, right: Expr)
+  case GreaterEqual(left: Expr, right: Expr)
+  case Less(left: Expr, right: Expr)
+  case LessEqual(left: Expr, right: Expr)
+  case Equal(left: Expr, right: Expr)
+  case NotEqual(left: Expr, right: Expr)
 
   // Unary
   case Negate(expr: Expr)

--- a/compiler/src/main/scala/grox/Expr.scala
+++ b/compiler/src/main/scala/grox/Expr.scala
@@ -1,62 +1,21 @@
 package grox
 
-// Todo add support for:
-// [ ] String literal
-// [ ] String operators
-// [ ] comparision operators with Order
-// [ ] variables
+type LiteralType = Double | String | Boolean | Null
 
-enum Expr[T]:
+enum Expr:
 
-  // math operators
-  case Plus(left: Expr[Double], right: Expr[Double]) extends Expr[Double]
-  case Minus(left: Expr[Double], right: Expr[Double]) extends Expr[Double]
-  case Times(left: Expr[Double], right: Expr[Double]) extends Expr[Double]
-  case Divide(left: Expr[Double], right: Expr[Double]) extends Expr[Double]
-  case Negate(expr: Expr[Double]) extends Expr[Double]
+  // Binary
+  case Add(left: Expr, right: Expr)
+  case Subtract(left: Expr, right: Expr)
+  case Multiply(left: Expr, right: Expr)
+  case Divide(left: Expr, right: Expr)
 
-  // logic operators
-  case Not(expr: Expr[Boolean]) extends Expr[Boolean]
-  case And(left: Expr[Boolean], right: Expr[Boolean]) extends Expr[Boolean]
-  case Or(left: Expr[Boolean], right: Expr[Boolean]) extends Expr[Boolean]
+  // Unary
+  case Negate(expr: Expr)
+  case Not(expr: Expr)
 
-  // comparision operators
-  case Greater(left: Expr[Double], right: Expr[Double]) extends Expr[Boolean]
-  case GreaterEqual(left: Expr[Double], right: Expr[Double]) extends Expr[Boolean]
-  case Less(left: Expr[Double], right: Expr[Double]) extends Expr[Boolean]
-  case LessEqual(left: Expr[Double], right: Expr[Double]) extends Expr[Boolean]
-  case Equal(left: Expr[T], right: Expr[T]) extends Expr[Boolean]
-  case NotEqual(left: Expr[T], right: Expr[T]) extends Expr[Boolean]
+  case Literal(value: LiteralType)
 
-  case Grouping(expr: Expr[T]) extends Expr[T]
+  case Grouping(expr: Expr)
 
-  case Bool(value: Boolean) extends Expr[Boolean]
-  case Num(value: Double) extends Expr[Double]
-
-  // case BoolVal(name: String) extends Expr[Boolean]
-  // case NumVal(name: String) extends Expr[Double]
-
-object Expr {
-
-  def eval[T](expr: Expr[T]): T =
-    expr match {
-      case Plus(left, right)         => eval(left) + eval(right)
-      case Minus(left, right)        => eval(left) - eval(right)
-      case Times(left, right)        => eval(left) * eval(right)
-      case Divide(left, right)       => eval(left) / eval(right)
-      case Negate(expr)              => -eval(expr)
-      case Not(expr)                 => !eval(expr)
-      case And(left, right)          => eval(left) && eval(right)
-      case Or(left, right)           => eval(left) || eval(right)
-      case Greater(left, right)      => eval(left) > eval(right)
-      case GreaterEqual(left, right) => eval(left) >= eval(right)
-      case Less(left, right)         => eval(left) < eval(right)
-      case LessEqual(left, right)    => eval(left) <= eval(right)
-      case Equal(left, right)        => eval(left) == eval(right)
-      case NotEqual(left, right)     => eval(left) != eval(right)
-      case Grouping(expr)            => eval(expr)
-      case Bool(value)               => value
-      case Num(value)                => value
-    }
-
-}
+object Expr {}

--- a/docs/grox/grammar.md
+++ b/docs/grox/grammar.md
@@ -13,5 +13,5 @@ grouping       → "(" expression ")" ;
 unary          → ( "-" | "!" ) expression ;
 binary         → expression operator expression ;
 operator       → "==" | "!=" | "<" | "<=" | ">" | ">="
-               | "+"  | "-"  | "*" | "/" | "and" | "or";
+               | "+"  | "-"  | "*" | "/" ;
 ```

--- a/docs/grox/grammar.md
+++ b/docs/grox/grammar.md
@@ -3,14 +3,15 @@
 ## Expression
 
 ```
-expression        → literal
-                  | operator
-                  | grouping ;
+expression     → literal
+               | unary
+               | binary
+               | grouping ;
 
-literal           → Double | Boolean ;
-grouping          → "(" expression ")" ;
-binary            → expression operator expression ;
-operator          → "==" | "!=" | "<" | "<=" | ">" | ">="
-                  | "+"  | "-"  | "*" | "/"
-                  | "&&" | "||" | "!" ;
+literal        → NUMBER | STRING | "true" | "false" | "nil" ;
+grouping       → "(" expression ")" ;
+unary          → ( "-" | "!" ) expression ;
+binary         → expression operator expression ;
+operator       → "==" | "!=" | "<" | "<=" | ">" | ">="
+               | "+"  | "-"  | "*" | "/" ;
 ```

--- a/docs/grox/grammar.md
+++ b/docs/grox/grammar.md
@@ -13,5 +13,5 @@ grouping       → "(" expression ")" ;
 unary          → ( "-" | "!" ) expression ;
 binary         → expression operator expression ;
 operator       → "==" | "!=" | "<" | "<=" | ">" | ">="
-               | "+"  | "-"  | "*" | "/" ;
+               | "+"  | "-"  | "*" | "/" | "and" | "or";
 ```


### PR DESCRIPTION
Implement lại `Expr` follow theo grammar trong quyển Carfting Interpreters.

Implement hơi khác một tí khi anh tách `Binary` thành các kiểu nhỏ hơn

```
Binary(Expr left, Token operator, Expr right) {
      this.left = left;
      this.operator = operator;
      this.right = right;
    }
```

thành

```
  case Add(left: Expr, right: Expr)
  case Subtract(left: Expr, right: Expr)
  case Multiply(left: Expr, right: Expr)
  case Divide(left: Expr, right: Expr)
```

Tương tự với `Unary`