### PR TITLE
Force using Scala 3 syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ inThisBuild(
 
 val commonSettings = Seq(
   scalacOptions -= "-Xfatal-warnings",
+  scalacOptions += "-source:future",
   libraryDependencies ++= Dependencies.all,
 )
 

--- a/compiler/src/main/scala/grox/Main.scala
+++ b/compiler/src/main/scala/grox/Main.scala
@@ -1,12 +1,12 @@
 package grox
 
 import cats.data.EitherT
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 
-import com.monovore.decline._
-import com.monovore.decline.effect._
-import grox.commands._
+import com.monovore.decline.*
+import com.monovore.decline.effect.*
+import grox.commands.*
 
 object Main
   extends CommandIOApp(
@@ -16,7 +16,7 @@ object Main
   ) {
 
   override def main: Opts[IO[ExitCode]] =
-    (ScannerCommand.scannerOpts orElse ParseCommand.parserOpts)
+    (ScannerCommand.scannerOpts `orElse` ParseCommand.parserOpts)
       .map {
         case cfg: ScannerCommand.Config => ScannerCommand.run(cfg)
         case cfg: ParseCommand.Config   => ParseCommand.run(cfg)

--- a/compiler/src/main/scala/grox/Parser.scala
+++ b/compiler/src/main/scala/grox/Parser.scala
@@ -1,6 +1,6 @@
 package grox
 
-import cats._
+import cats.*
 
 object Parser:
 

--- a/compiler/src/main/scala/grox/Scanner.scala
+++ b/compiler/src/main/scala/grox/Scanner.scala
@@ -1,8 +1,8 @@
 package grox
 
-import cats._
+import cats.*
 import cats.data.NonEmptyList
-import cats.parse.{LocationMap, Numbers => N, Parser => P, Parser0 => P0, Rfc5234 => R}
+import cats.parse.{LocationMap, Numbers as N, Parser as P, Parser0 as P0, Rfc5234 as R}
 
 object Scanner {
 

--- a/compiler/src/main/scala/grox/commands/ParseCommand.scala
+++ b/compiler/src/main/scala/grox/commands/ParseCommand.scala
@@ -1,15 +1,15 @@
 package grox.commands
 
-import cats._
-import cats.data._
-import cats.effect._
-import cats.effect.std._
-import cats.implicits._
+import cats.*
+import cats.data.*
+import cats.effect.*
+import cats.effect.std.*
+import cats.implicits.*
 
-import com.monovore.decline._
+import com.monovore.decline.*
 import grox.Parser.ParserAgl
 import grox.Scanner.ScannerAgl
-import grox._
+import grox.*
 import grox.utils.FileUtils.FileAgl
 import grox.utils.FileUtils.implicits.FileUtil
 

--- a/compiler/src/main/scala/grox/commands/ScannerCommand.scala
+++ b/compiler/src/main/scala/grox/commands/ScannerCommand.scala
@@ -1,13 +1,13 @@
 package grox.commands
 
-import cats._
-import cats.data._
-import cats.effect._
-import cats.effect.std._
-import cats.implicits._
+import cats.*
+import cats.data.*
+import cats.effect.*
+import cats.effect.std.*
+import cats.implicits.*
 
-import com.monovore.decline._
-import grox.Scanner._
+import com.monovore.decline.*
+import grox.Scanner.*
 import grox.Token
 import grox.utils.FileUtils.FileAgl
 import grox.utils.FileUtils.implicits.FileUtil

--- a/compiler/src/main/scala/grox/utils/FileUtils.scala
+++ b/compiler/src/main/scala/grox/utils/FileUtils.scala
@@ -3,9 +3,9 @@ package grox.utils
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
-import cats.effect._
-import cats.effect.implicits._
-import cats.implicits._
+import cats.effect.*
+import cats.effect.implicits.*
+import cats.implicits.*
 import cats.{Applicative, MonadError}
 
 object FileUtils {

--- a/compiler/src/test/scala/grox/ExprShowTest.scala
+++ b/compiler/src/test/scala/grox/ExprShowTest.scala
@@ -1,8 +1,8 @@
 package grox
 
-import cats.implicits._
+import cats.implicits.*
 
-import Expr._
+import Expr.*
 
 class ExprShowTest extends munit.FunSuite {
   test("Show single Add expression right") {


### PR DESCRIPTION
- Add `-source:future` scalacOption
- Remove Scala 2 syntax

Tham khảo: https://docs.scala-lang.org/scala3/guides/migration/tooling-migration-mode.html