### PR TITLE
fix: ci docs run failed

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version: 16.x
           cache: yarn
+          cache-dependency-path: website/yarn.lock
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
Details: https://github.com/grokking-vietnam/grox/runs/5954343345?check_suite_focus=true
Log: 
```
Error: Dependencies lock file is not found in /home/runner/work/grox/grox. Supported file patterns: yarn.lock
```
Solution: https://github.com/actions/setup-node#caching-packages-dependencies