### PR TITLE
Use Scala 3 Optional Braces style

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,8 @@ inThisBuild(
 val commonSettings = Seq(
   scalacOptions -= "-Xfatal-warnings",
   scalacOptions += "-source:future",
+  scalacOptions += "-rewrite",
+  scalacOptions += "-indent",
   libraryDependencies ++= Dependencies.all,
 )
 

--- a/compiler/src/main/scala/grox/Expr.scala
+++ b/compiler/src/main/scala/grox/Expr.scala
@@ -30,10 +30,10 @@ enum Expr:
 
   case Grouping(expr: Expr)
 
-object Expr {
+object Expr:
 
   def show(expr: Expr): String =
-    expr match {
+    expr match
       case Add(left, right) =>
         s"${formatNestedExpr(left, show(left))} + ${formatNestedExpr(right, show(right))}"
       case Subtract(left, right) =>
@@ -62,13 +62,10 @@ object Expr {
       case Grouping(expr) => s"${formatNestedExpr(expr, show(expr))})"
 
       case Literal(value) => value.toString
-    }
 
   private def formatNestedExpr(expr: Expr, exprShow: String): String =
-    expr match {
+    expr match
       case Literal(_) => exprShow
       case _          => s"($exprShow)"
-    }
 
   given exprShow: Show[Expr] = Show.show(Expr.show)
-}

--- a/compiler/src/test/scala/grox/ExprShowTest.scala
+++ b/compiler/src/test/scala/grox/ExprShowTest.scala
@@ -4,7 +4,7 @@ import cats.implicits.*
 
 import Expr.*
 
-class ExprShowTest extends munit.FunSuite {
+class ExprShowTest extends munit.FunSuite:
   test("Show single Add expression right") {
     val add = Expr.Add(Expr.Literal(1.0), Expr.Literal(2.0))
     assertEquals(add.show, "1.0 + 2.0")
@@ -76,4 +76,3 @@ class ExprShowTest extends munit.FunSuite {
     val not = Expr.Not(Expr.Literal(true))
     assertEquals(not.show, "!true")
   }
-}

--- a/compiler/src/test/scala/grox/ScannerQuickCheck.scala
+++ b/compiler/src/test/scala/grox/ScannerQuickCheck.scala
@@ -8,7 +8,7 @@ import cats.implicits.*
 import munit.ScalaCheckSuite
 import org.scalacheck.{Arbitrary, Gen, Prop}
 
-class ScannerQuickCheck extends ScalaCheckSuite {
+class ScannerQuickCheck extends ScalaCheckSuite:
 
   // generate random list of tokens
   // and put them together as input
@@ -58,5 +58,3 @@ class ScannerQuickCheck extends ScalaCheckSuite {
       ts <- Gen.listOfN(n, tokenGen)
       if ts.size > 0
     } yield ts
-
-}

--- a/compiler/src/test/scala/grox/ScannerTest.scala
+++ b/compiler/src/test/scala/grox/ScannerTest.scala
@@ -8,7 +8,7 @@ import cats.implicits.*
 import munit.CatsEffectSuite
 import org.scalacheck.{Arbitrary, Gen}
 
-class ScannerTest extends munit.FunSuite {
+class ScannerTest extends munit.FunSuite:
 
   test("whitespaces empty") {
     assertEquals(Scanner.whitespaces.parseAll(""), Right(()))
@@ -324,5 +324,3 @@ print Foo(); // expect: Foo instance"""
     )
     assertEquals(Scanner.parse(str), Right(expected))
   }
-
-}


### PR DESCRIPTION
Sử dụng `scalac` options để tự rewite sang scala 3 optional braces style.

```
scalacOptions += "-rewrite",
scalacOptions += "-indent"
```
Để tránh conflict mọi người thêm 2 dòng trên vào rồi compile, fmt là ok.
 