### PR TITLE
Implement Environment & Assign, Variable logic - Use State Monad & MonadTransformer - will be closed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,8 @@ val compiler = crossProject(JSPlatform, JVMPlatform)
   .settings(
     commonSettings,
     libraryDependencies ++= Seq(
-      Dependencies.catsParse.value
+      Dependencies.catsParse.value,
+      Dependencies.catsMtl.value,
     ),
   )
   .jsSettings(commonJsSettings)

--- a/cli/shared/src/main/scala/grox/cli/Main.scala
+++ b/cli/shared/src/main/scala/grox/cli/Main.scala
@@ -1,15 +1,13 @@
 package grox.cli
 
 import cats.Functor
+import cats.data.{EitherT, StateT}
 import cats.effect.*
 import cats.syntax.all.*
 
 import com.monovore.decline.*
 import com.monovore.decline.effect.*
-import grox.Executor
-import cats.data.StateT
-import grox.Environment
-import cats.data.EitherT
+import grox.{Environment, Executor}
 
 object Main
   extends CommandIOApp(

--- a/cli/shared/src/main/scala/grox/cli/Main.scala
+++ b/cli/shared/src/main/scala/grox/cli/Main.scala
@@ -1,7 +1,7 @@
 package grox.cli
 
 import cats.Functor
-import cats.data.{EitherT, StateT}
+import cats.data.StateT
 import cats.effect.*
 import cats.syntax.all.*
 
@@ -32,12 +32,12 @@ object Main
     case Command.Evaluate(str) => exec.evaluate(str).map(_.toString)
 
   given FileReader[IO] = FileReader.instance[IO]
-  val exec = Executor.module[EitherT[StateT[IO, Environment, *], Throwable, *]]
+  val exec = Executor.module[StateT[IO, Environment, *]]
 
   override def main: Opts[IO[ExitCode]] = CLI.parse.map {
     convertCommand[IO](_)
       .flatMap { cmd =>
-        eval(exec)(cmd).value.run(Environment())
+        eval(exec)(cmd).run(Environment())
       }
       .flatMap(x => IO.println(x._2.toString))
       .handleErrorWith { err =>

--- a/compiler/shared/src/main/scala/grox/Environment.scala
+++ b/compiler/shared/src/main/scala/grox/Environment.scala
@@ -25,8 +25,7 @@ class Environment(
 
   def get(
     name: String
-  ): Either[EnvironmentError, LiteralType] =
-    _get(name)
+  ): Either[EnvironmentError, LiteralType] = _get(name)
     .toRight(EnvironmentError.UndefinedVariableError(name))
 
   def assign(name: String, value: LiteralType): Either[EnvironmentError, Environment] =

--- a/compiler/shared/src/main/scala/grox/Environment.scala
+++ b/compiler/shared/src/main/scala/grox/Environment.scala
@@ -3,28 +3,28 @@ package grox
 import cats.implicits.catsSyntaxEither
 
 object Environment:
-  def apply(): Environment = new Environment(Map.empty[String, Token[Unit]], enclosing = None)
+  def apply: Environment = new Environment(Map.empty[String, LiteralType], enclosing = None)
 
 enum EnvironmentError(msg: String):
-  case UndefinedVariableError(variable: Token[Unit])
+  case UndefinedVariableError(variable: String)
     extends EnvironmentError(s"Undefined variable: '$variable'.")
 
 class Environment(
-  private val values: Map[String, Token[Unit]],
+  private val values: Map[String, LiteralType],
   private val enclosing: Option[Environment],
 ):
 
-  def define(name: String, value: Token[Unit]): Environment =
+  def define(name: String, value: LiteralType): Environment =
     new Environment(values + (name -> value), enclosing)
 
   def get(
-    name: Token[Unit]
-  ): Option[Token[Unit]] = values.get(name.lexeme).orElse(enclosing.flatMap(_.get(name)))
+    name: String
+  ): Option[LiteralType] = values.get(name).orElse(enclosing.flatMap(_.get(name)))
 
-  def assign(name: Token[Unit], value: Token[Unit]): Either[EnvironmentError, Environment] =
+  def assign(name: String, value: LiteralType): Either[EnvironmentError, Environment] =
     val assignEither =
-      if (values.contains(name.lexeme))
-        Right(new Environment(values + (name.lexeme -> value), enclosing))
+      if (values.contains(name))
+        Right(new Environment(values + (name -> value), enclosing))
       else
         Left(EnvironmentError.UndefinedVariableError(name))
 

--- a/compiler/shared/src/main/scala/grox/Executor.scala
+++ b/compiler/shared/src/main/scala/grox/Executor.scala
@@ -2,6 +2,7 @@ package grox
 
 import cats.MonadThrow
 import cats.implicits.*
+import cats.mtl.Stateful
 
 trait Executor[F[_]]:
   def scan(str: String): F[List[Token[Span]]]
@@ -31,7 +32,7 @@ object Executor:
           result <- interpreter.evaluate(expr)
         yield result
 
-  def module[F[_]: MonadThrow]: Executor[F] =
+  def module[F[_]: MonadThrow](using S: Stateful[F, Environment]): Executor[F] =
     given Scanner[F] = Scanner.instance[F]
     given Parser[F] = Parser.instance[F]
     given Interpreter[F] = Interpreter.instance[F]

--- a/compiler/shared/src/main/scala/grox/Expr.scala
+++ b/compiler/shared/src/main/scala/grox/Expr.scala
@@ -23,10 +23,6 @@ enum Expr:
   case Equal(left: Expr, right: Expr)
   case NotEqual(left: Expr, right: Expr)
 
-  // assignment
-
-  case Assign[A](name: Token[A], value: Expr)
-
   // logic
   case Or(left: Expr, right: Expr)
   case And(left: Expr, right: Expr)
@@ -39,7 +35,9 @@ enum Expr:
 
   case Grouping(expr: Expr)
 
-  case Variable[A](name: Token[A])
+  // assignment
+  case Assign(name: Token[Unit], value: Expr)
+  case Variable[A](name: Token[Unit])
 
 object Expr:
 

--- a/compiler/shared/src/main/scala/grox/Interpreter.scala
+++ b/compiler/shared/src/main/scala/grox/Interpreter.scala
@@ -101,16 +101,6 @@ object Interpreter:
     right: LiteralType,
   ): EvaluationResult = equal(left, right).flatMap(r => !r)
 
-  // Implement Environment for Assign and Variable cases by using cats-mtl library
-  // cats-mlt is a Monad Transformer library for Cats
-  // which help us write polymophic programs using Monad Transformers
-  // The refactor will follow these step:
-  // 1. Use [F[_]: MonadThrow] instead of Either
-  // 2. Use Stateful[F, Environment] for State
-  // resources:
-  // https://typelevel.org/cats-mtl/getting-started.html
-  // https://typelevel.org/blog/2018/10/06/intro-to-mtl.html
-
   def evaluate[F[_]: MonadThrow](expr: Expr)(using S: Stateful[F, Environment]): F[LiteralType] =
     expr match
       case Expr.Literal(value) => value.pure[F]

--- a/compiler/shared/src/main/scala/grox/Interpreter.scala
+++ b/compiler/shared/src/main/scala/grox/Interpreter.scala
@@ -3,15 +3,16 @@ package grox
 import scala.util.control.NoStackTrace
 
 import cats.*
+import cats.mtl.Stateful
 import cats.syntax.all.*
 import cats.syntax.apply.*
-import cats.mtl.Stateful
 
 trait Interpreter[F[_]]:
   def evaluate(expr: Expr): F[LiteralType]
 
 object Interpreter:
-  def instance[F[_]: MonadThrow](using S: Stateful[F, Environment]): Interpreter[F] = expr => evaluate(expr)
+  def instance[F[_]: MonadThrow](using S: Stateful[F, Environment]): Interpreter[F] =
+    expr => evaluate(expr)
 
   enum RuntimeError(op: Token[Unit], msg: String) extends NoStackTrace:
     override def toString = msg
@@ -44,7 +45,9 @@ object Interpreter:
   )(
     left: Expr,
     right: Expr,
-  )(using S: Stateful[F, Environment]): F[LiteralType] = (evaluate(left), evaluate(right)).mapN(eval).map(_.liftTo[F]).flatten
+  )(
+    using S: Stateful[F, Environment]
+  ): F[LiteralType] = (evaluate(left), evaluate(right)).mapN(eval).map(_.liftTo[F]).flatten
 
   def add(left: LiteralType, right: LiteralType): EvaluationResult =
     (left, right) match

--- a/compiler/shared/src/main/scala/grox/Parser.scala
+++ b/compiler/shared/src/main/scala/grox/Parser.scala
@@ -1,9 +1,8 @@
 package grox
 
 import scala.annotation.tailrec
-import scala.reflect.{ClassTag, TypeTest}
+import scala.reflect.{ClassTag, TypeTest, Typeable}
 import scala.util.control.NoStackTrace
-import scala.reflect.Typeable
 
 import cats.*
 import cats.implicits.*

--- a/compiler/shared/src/main/scala/grox/Parser.scala
+++ b/compiler/shared/src/main/scala/grox/Parser.scala
@@ -3,6 +3,7 @@ package grox
 import scala.annotation.tailrec
 import scala.reflect.{ClassTag, TypeTest}
 import scala.util.control.NoStackTrace
+import scala.reflect.Typeable
 
 import cats.*
 import cats.implicits.*
@@ -141,6 +142,7 @@ object Parser:
       cnsm <- consume[A, Semicolon[A]](pr._2)
     } yield (Stmt.Print(pr._1), cnsm._2)
 
+  // TODO:
   def consume[A, TokenType <: Token[A]: ClassTag](
     tokens: List[Token[A]]
   ): Either[Error[A], (Token[A], List[Token[A]])] =

--- a/compiler/shared/src/test/scala/grox/InterpreterTest.scala
+++ b/compiler/shared/src/test/scala/grox/InterpreterTest.scala
@@ -1,11 +1,17 @@
 package grox
 
+import cats.Eval
+import cats.data.{EitherT, StateT}
+
+import grox.Interpreter.RuntimeError
 import munit.ScalaCheckSuite
 import org.scalacheck.Prop.*
 
-import Interpreter.*
-
 class InterpreterTest extends ScalaCheckSuite:
+
+  val interpreter = Interpreter.instance[EitherT[StateT[Eval, Environment, *], Throwable, *]]
+
+  val evaluate = (x: Expr) => interpreter.evaluate(x).value.run(Environment()).value._2
 
   property("addition") {
     forAll { (n1: Double, n2: Double) =>
@@ -68,16 +74,16 @@ class InterpreterTest extends ScalaCheckSuite:
 
   // from: https://www.learncbse.in/bodmas-rule/
   test("complex expression -4*(10+15/5*4-2*2)") {
-    def evaluate(str: String) = Scanner
+    def eval(str: String) = Scanner
       .parse(str)
       .flatMap(Parser.parse(_))
-      .flatMap(e => Interpreter.evaluate(e._1))
-    val expr = evaluate("-4*(10+15/5*4-2*2)")
-    val division = evaluate("-4*(10+3*4-2*2)")
-    val multiplication = evaluate("-4*(10+12-4)")
-    val addition = evaluate("-4*(22-4)")
-    val subtraction = evaluate("-4*18")
-    val answer = evaluate("-72")
+      .flatMap(e => evaluate(e._1))
+    val expr = eval("-4*(10+15/5*4-2*2)")
+    val division = eval("-4*(10+3*4-2*2)")
+    val multiplication = eval("-4*(10+12-4)")
+    val addition = eval("-4*(22-4)")
+    val subtraction = eval("-4*18")
+    val answer = eval("-72")
     assertEquals(expr, division)
     assertEquals(division, multiplication)
     assertEquals(multiplication, addition)

--- a/docs/grox/grammar.md
+++ b/docs/grox/grammar.md
@@ -9,7 +9,7 @@ expression     -> literal
                | grouping ;
 
 literal        -> NUMBER | STRING | "true" | "false" | "nil" ;
-logical        
+logical
 grouping       -> "(" expression ")" ;
 unary          -> ( "-" | "!" ) expression ;
 binary         -> expression operator expression ;
@@ -22,13 +22,13 @@ operator       -> "==" | "!=" | "<" | "<=" | ">" | ">="
 expression    -> IDENTIFIER "=" assignment
                | logic_or ;
 logic_or      -> logic_and ( "or" logic_and )* ;
-logic_and     -> equality ( "and" equality )* ; 
+logic_and     -> equality ( "and" equality )* ;
 assignment    -> IDENTIFIER "=" assignment | equality
 equality      -> comparison (("!=" | "==") comparison)*
 comparison    -> factor (("<" | "<=" | ">" | ">=") factor)*
-factor        -> term (("+" | "-") term)* 
+factor        -> term (("+" | "-") term)*
 term          -> unary (("*" | "/") unary)*
-unary         -> ("-" | "!") unary 
+unary         -> ("-" | "!") unary
               | primary
 primary       -> "true" | "false" | "nil"
               | NUMBER | STRING
@@ -56,5 +56,18 @@ ifStmt         → "if" "(" expression ")" statement
 printStmt      → "print" expression ";" ;
 returnStmt     → "return" expression? ";" ;
 whileStmt      → "while" "(" expression ")" statement ;
+
 block          → "{" declaration* "}" ;
+declaration    → classDecl
+               | funDecl
+               | varDecl
+               | statement ;
+classDecl      → "class" IDENTIFIER ( "<" IDENTIFIER )?
+                 "{" function* "}" ;
+funDecl        → "fun" function ;
+varDecl        → "var" IDENTIFIER ( "=" expression )? ";" ;
+
+function       → IDENTIFIER "(" parameters? ")" block ;
+parameters     → IDENTIFIER ( "," IDENTIFIER )* ;
+arguments      → expression ( "," expression )* ;
 ```

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Dependencies {
   val catsCore = Def.setting("org.typelevel" %%% "cats-core" % "2.8.0")
   val catsEffect = Def.setting("org.typelevel" %%% "cats-effect" % "3.3.13")
   val catsParse = Def.setting("org.typelevel" %%% "cats-parse" % "0.3.8")
+  val catsMtl = Def.setting("org.typelevel" %%% "cats-mtl" % "1.3.0")
 
   val fs2 = Def.setting("co.fs2" %%% "fs2-core" % fs2Version)
   val fs2IO = Def.setting("co.fs2" %%% "fs2-io" % fs2Version)


### PR DESCRIPTION
# closed

- Implement Environment class
- Implement Assign and Variable cases with cats-mtl library
- cats-mlt is a Monad Transformer library for Cats which help us write polymorphic programs using Monad Transformers
 
The implement follows these step:
  1. Use [F[_]: MonadThrow] instead of Either
  2. Use Stateful[F, Environment] for State
  3. Fix tests

resources:
- [State](https://typelevel.org/cats/datatypes/state.html)
- [StateT](https://typelevel.org/cats/datatypes/statet.html)
- [cats-mtl](https://typelevel.org/cats-mtl/getting-started.html)
- [cats-mtl intro blog](https://typelevel.org/blog/2018/10/06/intro-to-mtl.html)

TODO:
- [ ] `Id` instead of `Eval` in `Playground`?
- [x] Fix output of cli evaluate ( now run `bloop run cliJVM -- evaluate examples/multiline.lox` returns Right(6.0), before returns 6.0)
- [ ] Make sure this works with everything (cli, repl, playground).
- [ ] Remove duplicated code in Playground.scala
- [ ] Implement Statement execution
